### PR TITLE
crdbutil: fix user table scan query

### DIFF
--- a/src/go/src/rubrik/util/crdbutil/connection.go
+++ b/src/go/src/rubrik/util/crdbutil/connection.go
@@ -210,7 +210,7 @@ func openDBAsRoot(
 }
 
 func getUsers(db *sql.DB) ([]string, error) {
-	rows, err := db.Query("SHOW USERS")
+	rows, err := db.Query("SELECT username FROM system.users")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Informs recent failures on https://github.com/cockroachdb/cockroach/issues/44066, https://github.com/cockroachdb/cockroach/issues/43284, https://github.com/cockroachdb/cockroach/issues/45645, https://github.com/cockroachdb/cockroach/issues/43273, https://github.com/cockroachdb/cockroach/issues/43839, https://github.com/cockroachdb/cockroach/issues/41528.

https://github.com/cockroachdb/cockroach/pull/45827 broke the query to
retrieve users from the database, it was previously expecting one column,
and needs to be updated to accept three.

Previous to #45827 the column name was `user_name` (it's not
`username`), so the binary built off LATEST is not suitable for
roachtests run on v19.2 and below. I'm not sure how to construct a query
that would work across the two versions, we'll add a patch to previous
release branches to use a fixed SHA from this repo.