### PR TITLE
sqlapp: ignore benign unexpected EOF errors

### DIFF
--- a/src/go/src/rubrik/sqlapp/coordinator/main.go
+++ b/src/go/src/rubrik/sqlapp/coordinator/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/exec"
 	"path"
@@ -13,14 +15,10 @@ import (
 	"time"
 
 	"rubrik/sqlapp"
-
-	_ "github.com/lib/pq"
-
-	"net/http"
-	_ "net/http/pprof"
-
 	"rubrik/sqlapp/job"
 	"rubrik/util/log"
+
+	_ "github.com/lib/pq"
 )
 
 const (
@@ -71,10 +69,7 @@ func getDefaultArgs(args basicArgs) []string {
 	return ret
 }
 
-func appendCockroachIPAddrFlag(
-	workerArgs []string,
-	ipAddrsCSV string,
-) []string {
+func appendCockroachIPAddrFlag(workerArgs []string, ipAddrsCSV string) []string {
 	return append(
 		workerArgs,
 		fmt.Sprintf("--%s=%s", sqlapp.CockroachIPAddressesCSV, ipAddrsCSV),
@@ -185,7 +180,7 @@ func analyzeTestResults(ctx context.Context, results chan testResult) int {
 	log.Info(
 		ctx,
 		"Analysing test results. Please bear in mind that "+
-			"log.Fatal() causes process to exit with status 255",
+			"log.Fatal() causes process to exit with status 1",
 	)
 	for result := range results {
 		if result.err != nil {

--- a/src/go/src/rubrik/util/log/log.go
+++ b/src/go/src/rubrik/util/log/log.go
@@ -26,12 +26,12 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 
 func Fatalf(ctx context.Context, format string, args ...interface{}) {
 	log.Printf(format, args...)
-	os.Exit(255)
+	os.Exit(1)
 }
 
 func Fatal(ctx context.Context, args ...interface{}) {
 	log.Print(args...)
-	os.Exit(255)
+	os.Exit(1)
 }
 
 func V(depth int) bool {


### PR DESCRIPTION
## sqlapp: ignore benign unexpected EOF errors

AFAICT these errors come up from
https://github.com/lib/pq/blob/9eb3fc897d6fd97dd4aad3d0404b54e2f7cc56be/conn.go#L939,
when running under chaos and the server terminates mid-way through
execution. Given the tight loops these scaledata tests are running
under, we're more likely to hit it than not. Fixes
https://github.com/cockroachdb/cockroach/issues/46960.

I verified this works by manually inserting these errors midway through
the test run.

---

## sqlapp,util: exit with error code: 1 to distinguish from SSH errors

See https://github.com/cockroachdb/cockroach/pull/48231.
